### PR TITLE
Feature/sort messages by the shortest validity date

### DIFF
--- a/dist/idf-mobilite.js
+++ b/dist/idf-mobilite.js
@@ -420,10 +420,19 @@ class IDFMobiliteCard extends LitElement {
         if (messagesList && messagesList.attributes['Siri']) {
             const deliveryMessages = messagesList.attributes['Siri'].ServiceDelivery.GeneralMessageDelivery[0]
             if (deliveryMessages.InfoMessage) {
-                deliveryMessages.InfoMessage.forEach(infoMessage => {
-                    if (!messages[infoMessage.InfoChannelRef.value])
-                        messages[infoMessage.InfoChannelRef.value] = { messages: [] }
-                    messages[infoMessage.InfoChannelRef.value].messages.push(infoMessage.Content.Message[0].MessageText.value)
+                deliveryMessages.InfoMessage
+                .sort((a, b) => { // sort messages from the shortest validity
+                    const data_a = new Date(a.ValidUntilTime);
+                    const data_b = new Date(b.ValidUntilTime);
+                    return ((data_a < data_b) ? -1 : ((data_a > data_b) ? 1 : 0));
+                })
+                .forEach(infoMessage => {
+                    // show only messages which are still valid
+                    if (new Date(infoMessage.ValidUntilTime) > new Date()) {
+                        if (!messages[infoMessage.InfoChannelRef.value])
+                            messages[infoMessage.InfoChannelRef.value] = { messages: [] }
+                        messages[infoMessage.InfoChannelRef.value].messages.push(infoMessage.Content.Message[0].MessageText.value)
+                    }
                 })
             }
         }

--- a/dist/idf-mobilite.js
+++ b/dist/idf-mobilite.js
@@ -438,21 +438,29 @@ class IDFMobiliteCard extends LitElement {
         }
 
         const imagesUrl = new URL('images/', import.meta.url).href
+        let displayedTextLength = 0;
+        const messageText = Object.keys(messages).map(key => {
+            let concatMessage = "";
+            messages[key].messages.forEach((message, index) => { concatMessage += message + (index < messages[key].messages.length - 1 ? " /// " : "") })
+            if (key == "Information" && this.config.display_info_message === true) {
+                displayedTextLength += concatMessage.length;
+                return html`<img src="${imagesUrl}general/info.png" class="message-icon">${concatMessage}`
+            } else if (key == "Perturbation") {
+                displayedTextLength += concatMessage.length;
+                return html`<img src="${imagesUrl}general/warning.png" class="message-icon">${concatMessage}`
+            } else if (key == "Commercial" && this.config.display_commercial_message === true) {
+                displayedTextLength += concatMessage.length;
+                return concatMessage
+            }
+        });
+        const textSpeed = Math.max(Math.floor(displayedTextLength / 10), 5); // set min speed to 5 for very short texts
+
         return html`
             <div class="message-div ${this.config.show_screen === true ? "with-screen" : this.config.wall_panel === true ? "footer-nobg " : ""}">
-                ${Object.keys(messages).length > 0 ?
-                html`<div class="message-div-text">
-                        ${Object.keys(messages).map(key => {
-                    var concatMessage = "";
-                    messages[key].messages.forEach((message, index) => { concatMessage += message + (index < messages[key].messages.length - 1 ? " /// " : "") })
-                    if (key == "Information" && this.config.display_info_message === true)
-                        return html`<img src="${imagesUrl}info.png" class="message-icon">${concatMessage}`
-                    else if (key == "Perturbation")
-                        return html`<img src="${imagesUrl}warning.png" class="message-icon">${concatMessage}`
-                    else if (key == "Commercial" && this.config.display_commercial_message === true)
-                        return concatMessage
-                })}</div>`
-                : ""}
+                ${messageText.length > 0 ?
+                    html`<div class="message-div-text" style="animation: ScrollMessage ${textSpeed}s linear infinite;">${messageText}</div>`
+                    : ""
+                }
             </div>`
     }
 
@@ -915,7 +923,6 @@ class IDFMobiliteCard extends LitElement {
                 justify-content: right;
                 flex-grow: 1;
                 white-space: nowrap;
-                animation: ScrollMessage 60s linear infinite;
             }
             .message-icon {
                 align-self: center;


### PR DESCRIPTION
Hi! This is something that I came across this weekend when using your card.
1. I was going out and I checked the train. I needed to wait a bit to read the part of the message which was important. What I noticed is that mostly the most important message will have the shortest validity date. Now the messages are sorted by the shortest validity date.
2. I added a condition which will concatenate only a message which is still valid - I don't know if PRIM servers can hold any message which has been expired but it might be useful to check it anyway.
3. When the text message is too long, its animation speed is too fast to read anything. Now the speed animation is based on the text length with the condition that the minimum value is set to 5.

PS. I have more ideas to add after few days of practical tests. I hope that you don't mind if I push more PRs...