### PR TITLE
Add filtering based on train mission names

### DIFF
--- a/dist/idf-mobilite-card-editor.js
+++ b/dist/idf-mobilite-card-editor.js
@@ -73,12 +73,20 @@ class IDFMobiliteCardEditor extends LitElement {
       return this._config.exclude_lines_ref || "";
     }
 
+    get _exclude_lines_missions() {
+      return this._config.exclude_lines_missions || "";
+    }
+
     get _exclude_second_lines() {
       return this._config.exclude_second_lines || "";
     }
 
     get _exclude_second_lines_ref() {
       return this._config.exclude_second_lines_ref || "";
+    }
+
+    get _exclude_second_lines_missions() {
+      return this._config.exclude_second_lines_missions || "";
     }
 
     get _show_train_ref() {
@@ -165,6 +173,12 @@ class IDFMobiliteCardEditor extends LitElement {
                       @input="${this._valueChanged}"
                     ></ha-textfield>
                     <ha-textfield
+                      label="Exclure les missions (ex: VOLA;POPI;PASA;)"
+                      .value="${this._exclude_lines_missions}"
+                      .configValue=${"exclude_lines_missions"}
+                      @input="${this._valueChanged}"
+                    ></ha-textfield>
+                    <ha-textfield
                       label="Exclure les lignes 2ème ligne (ex: bus-206;metro-1;tram-T2;rer-A;train-R;)"
                       .value="${this._exclude_second_lines}"
                       .configValue=${"exclude_second_lines"}
@@ -174,6 +188,12 @@ class IDFMobiliteCardEditor extends LitElement {
                       label="Exclure les destinations 2ème ligne (ex: 458755;5655442;)"
                       .value="${this._exclude_second_lines_ref}"
                       .configValue=${"exclude_second_lines_ref"}
+                      @input="${this._valueChanged}"
+                    ></ha-textfield>
+                    <ha-textfield
+                      label="Exclure les missions 2ème ligne (ex: VOLA;POPI;PASA;)"
+                      .value="${this._exclude_second_lines_missions}"
+                      .configValue=${"exclude_second_lines_missions"}
                       @input="${this._valueChanged}"
                     ></ha-textfield>
                     <div class="switch">

--- a/dist/idf-mobilite.js
+++ b/dist/idf-mobilite.js
@@ -63,11 +63,11 @@ class IDFMobiliteCard extends LitElement {
                     <div class="idf-${this.config.show_screen === true ? "with-" : ""}screen">
                         <div class="card-content${this.config.show_screen === true ? "-with-screen" : this.config.wall_panel === true ? "-nobg" : ""}">
                             ${this.config.lineType === "RER"
-                                ? this.createRERContent(this.hass.states[this.config.entity], this.config.exclude_lines, this.config.exclude_lines_ref) : ""}
+                                ? this.createRERContent(this.hass.states[this.config.entity], this.config.exclude_lines, this.config.exclude_lines_ref, this.config.exclude_lines_missions) : ""}
                             ${this.config.lineType === "BUS"
                                 ? this.createBUSContent(this.hass.states[this.config.entity], this.config.exclude_lines, this.config.exclude_lines_ref) : ""}
                             ${this.config.second_entity && this.config.lineType === "RER"
-                                ? this.createRERContent(this.hass.states[this.config.second_entity], this.config.exclude_second_lines, this.config.exclude_second_lines_ref, true) : ""}
+                                ? this.createRERContent(this.hass.states[this.config.second_entity], this.config.exclude_second_lines, this.config.exclude_second_lines_ref, this.config.exclude_second_lines_missions, true) : ""}
                             ${this.config.second_entity && this.config.lineType === "BUS"
                                 ? this.createBUSContent(this.hass.states[this.config.second_entity], this.config.exclude_second_lines, this.config.exclude_second_lines_ref, true) : ""}
                             ${this.createMessageDisplay()}
@@ -86,7 +86,7 @@ class IDFMobiliteCard extends LitElement {
         `;
     }
 
-    createRERContent(lineDatas, exclude_lines, exclude_lines_ref, second_entity) {
+    createRERContent(lineDatas, exclude_lines, exclude_lines_ref, exclude_lines_missions, second_entity) {
         const messagesList = this.hass.states[this.config.messages];
         if (!lineDatas?.attributes['Siri']  || !lineDatas.attributes['Siri']?.ServiceDelivery?.StopMonitoringDelivery[0].ResponseTimestamp)
             return html``
@@ -133,7 +133,8 @@ class IDFMobiliteCard extends LitElement {
                     if (lineRef != "") {
                         const nextDeparture = Math.floor((new Date(Date.parse(stop.MonitoredVehicleJourney.MonitoredCall.ExpectedDepartureTime)) - Date.now()) / 1000 / 60)
                         const lineStop = stop.MonitoredVehicleJourney.DestinationRef.value.substring(stop.MonitoredVehicleJourney.DestinationRef.value.indexOf(":Q:") + 3, stop.MonitoredVehicleJourney.DestinationRef.value.length - 1)
-                        if ((!exclude_lines || exclude_lines.indexOf(lineRef) == -1) && (!exclude_lines_ref || exclude_lines_ref.indexOf(lineStop) == -1) && nextDeparture > -5 && nextDeparture < 60) {
+                        const mission = stop.MonitoredVehicleJourney.JourneyNote != "" ? stop.MonitoredVehicleJourney.JourneyNote[0].value : ""
+                        if ((!exclude_lines || exclude_lines.indexOf(lineRef) == -1) && (!exclude_lines_ref || exclude_lines_ref.indexOf(lineStop) == -1) && (!exclude_lines_missions || exclude_lines_missions.indexOf(mission) == -1) && nextDeparture > -5 && nextDeparture < 60) {
                             const destinationName = stop.MonitoredVehicleJourney.DirectionName.length > 0 ? stop.MonitoredVehicleJourney.DirectionName[0].value.split('-').map(item => item.charAt(0).toUpperCase() + item.slice(1).toLowerCase()).join('-').split(' ').map(item => item.charAt(0).toUpperCase() + item.slice(1)).join(' ') : stop.MonitoredVehicleJourney.MonitoredCall.DestinationDisplay[0].value
                             if (!trains[lineRef])
                                 trains[lineRef] = {}


### PR DESCRIPTION
### Description
Add filtering based on mission names (JourneyNote).

### Use case
Some trains with the same terminus number don't stop at my station and are thus irrelevant. 
Moreover, the number of trains can be overwhelming (more than 10 per hour) and this can help filter some of those.

### Example
VOLA, POPI, PASA, etc.

<img width="366" alt="image" src="https://github.com/yyrkoon94/lovelace-idf-mobilite/assets/15892040/af27e65d-90c7-4854-b237-4f0001a6c0d6">